### PR TITLE
[PPSSPP] Disable Kernel-Mode Input functions

### DIFF
--- a/source/src/main.c
+++ b/source/src/main.c
@@ -717,7 +717,10 @@ static int load_ku_bridge_prx(int devkit_version)
     }
 
     init_ku_bridge(devkit_version);
-    init_input_kernel();
+
+	// Kernel-Mode input functions don't work with PPSSPP - disable these so input works on both
+	// real hardware and PSP emulation via PPSSPP
+    // init_input_kernel();
 
     if (devkit_version >= 0x03050210)
       __draw_volume_status = draw_volume_status;


### PR DESCRIPTION
When playing via the PPSSPP emulator, input would work on the game menus, but wouldn't work once in-game.  Disabling Kernel Mode input functions fixes this and shouldn't affect gameplay on a real PSP.