### PR TITLE
Fix manual save state crashes, menu-exit quit, and stale code after loading a state

### DIFF
--- a/source/src/gui.c
+++ b/source/src/gui.c
@@ -1999,6 +1999,14 @@ u32 menu(void)
 
   void gamepak_file_reopen(void)
   {
+    // A RAM-resident ROM is never read through this handle, so failing to
+    // reopen it is not fatal. Only paged ROMs genuinely cannot continue.
+    if (gamepak_size <= gamepak_ram_buffer_size)
+    {
+      gamepak_file_large = -1;
+      return;
+    }
+
     for (i = 0; i < 5; i++)
     {
       FILE_OPEN(gamepak_file_large, gamepak_filename_raw, READ);

--- a/source/src/gui.c
+++ b/source/src/gui.c
@@ -1263,6 +1263,17 @@ static void get_savestate_info(char *filename, u16 *snapshot, char *timestamp)
   scePowerUnlock(0);
 }
 
+// Reads the screenshot a save state was written with, for the slot preview in
+// the save-state menu. get_savestate_info fills the buffer with a "no state"
+// placeholder when the slot is empty.
+static void load_savestate_preview(u32 slot, u16 *preview, char *timestamp)
+{
+  char state_filename[MAX_FILE];
+
+  get_savestate_filename(slot, state_filename);
+  get_savestate_info(state_filename, preview, timestamp);
+}
+
 static void get_savestate_filename(u32 slot, char *name_buffer)
 {
   char savestate_ext[16];
@@ -2233,11 +2244,39 @@ u32 menu(void)
   set_cpu_clock(PSP_CLOCK_222);
   
   choose_menu(&main_menu);
-  
+
+  // Save-state slot preview. While a slot row is highlighted the panel shows
+  // that slot's saved screenshot instead of the paused game; anywhere else it
+  // shows the live screen. Refreshed only when the highlighted row changes,
+  // because each refresh reads a screenshot off the memory stick.
+  MenuType *previewed_menu = NULL;
+  u32 previewed_option = (u32)-1;
+
+  #define REFRESH_SAVESTATE_PREVIEW()                                         \
+    do {                                                                      \
+      if (current_menu == &savestate_menu && current_option != NULL &&         \
+          current_option->line_number < 10 && savestate_screen != NULL)        \
+      {                                                                       \
+        savestate_slot = current_option->line_number;                          \
+        load_savestate_preview(savestate_slot, savestate_screen, line_buffer); \
+        screen_image_ptr = savestate_screen;                                   \
+      }                                                                       \
+      else                                                                    \
+      {                                                                       \
+        screen_image_ptr = current_screen;                                     \
+      }                                                                       \
+    } while (0)
 
   while (repeat)
   {
     clear_screen(COLOR15_TO_32(COLOR_BG));
+
+    if (current_menu != previewed_menu || current_option_num != previewed_option)
+    {
+      previewed_menu = current_menu;
+      previewed_option = current_option_num;
+      REFRESH_SAVESTATE_PREVIEW();
+    }
 
     if ((counter % 30) == 0)
 	{

--- a/source/src/gui.c
+++ b/source/src/gui.c
@@ -152,9 +152,13 @@ typedef struct _MenuType MenuType;
   STRING_SELECTION_OPTION                                                     \
 }                                                                             \
 
+// action_function is deliberately NULL: it used to hold menu_select_savestate,
+// a nested function, and calling through that pointer jumped to a wild address
+// (bus error, EPC 0EAFE6A0). The slot rows are dispatched inline in
+// CURSOR_SELECT instead, matching how every other action option here works.
 #define SAVESTATE_OPTION(number)                                              \
 {                                                                             \
-  menu_select_savestate,                                                      \
+  NULL,                                                                       \
   NULL,                                                                       \
   NULL,                                                                       \
   savestate_timestamps[number],                                               \
@@ -2392,7 +2396,43 @@ u32 menu(void)
             break;
 
           case ACTION_OPTION:
-            if (current_option->action_function != NULL)
+            // The save-state submenu's rows share line numbers with the main
+            // menu's own actions, so resolve them by menu first.
+            if (current_menu == &savestate_menu)
+            {
+              if (current_option->line_number < 10)
+              {
+                // A slot row: savestate_action selects save versus load.
+                savestate_slot = current_option->line_number;
+
+                if (savestate_action != 0)
+                  action_savestate();
+                else
+                  action_loadstate();
+
+                return_value = 1;
+                repeat = 0;
+              }
+              else if (current_option->line_number == 11)
+              {
+                // "Load state from file": browse dir_state for a .svs.
+                const char *state_ext[] = { ".svs", NULL };
+
+                if (load_file(state_ext, filename_buffer, dir_state) == 0 && !first_load)
+                {
+                  load_state(filename_buffer);
+                  return_value = 1;
+                  repeat = 0;
+                }
+                else
+                {
+                  menu_init();
+                  choose_menu(current_menu);
+                  counter = 0;
+                }
+              }
+            }
+            else if (current_option->action_function != NULL)
               current_option->action_function();
             else
             {

--- a/source/src/memory.c
+++ b/source/src/memory.c
@@ -3536,13 +3536,28 @@ static s32 load_gamepak_raw(char *name)
       return -1;
     }
 
+    // Record the ROM's absolute path whichever load path is taken. Everything
+    // that reopens the gamepak reads gamepak_filename_raw, and leaving it empty
+    // for RAM-resident ROMs made those reopens fail.
+    if (strrchr(name, '/') != NULL)
+    {
+      strcpy(gamepak_filename_raw, name);
+    }
+    else
+    {
+      char current_dir[MAX_PATH];
+
+      getcwd(current_dir, MAX_PATH);
+      sprintf(gamepak_filename_raw, "%s/%s", current_dir, name);
+    }
+
     // If it's a big file size keep it don't close it, we'll
     // probably want to load it later
     if (_gamepak_size <= gamepak_ram_buffer_size)
     {
       FILE_READ(gamepak_file, gamepak_rom, _gamepak_size);
       FILE_CLOSE(gamepak_file);
-      
+
       // Validate GBA ROM header - check for Nintendo logo at 0x04-0xA0
       // At minimum, check the first 4 bytes after entry point
       if (_gamepak_size >= 0x100) {
@@ -3557,7 +3572,7 @@ static s32 load_gamepak_raw(char *name)
     {
       // Read in just enough for the header
       FILE_READ(gamepak_file, gamepak_rom, 0x100);
-      
+
       // Validate GBA ROM header for large files too
       u8 *header = gamepak_rom + 0x04;
       // Check for part of the Nintendo logo (known bytes)
@@ -3567,18 +3582,6 @@ static s32 load_gamepak_raw(char *name)
       }
 
       gamepak_file_large = gamepak_file;
-
-      if (strrchr(name, '/') != NULL)
-      {
-        strcpy(gamepak_filename_raw, name);
-      }
-      else
-      {
-        char current_dir[MAX_PATH];
-
-        getcwd(current_dir, MAX_PATH);
-        sprintf(gamepak_filename_raw, "%s/%s", current_dir, name);
-      }
     }
 
     return _gamepak_size;
@@ -3785,6 +3788,29 @@ void load_state(char *savestate_filename)
     oam_update = 1;
     gbc_sound_update = 1;
     reg[CHANGED_PC_STATUS] = 1;
+
+    // Every translated block was compiled against the memory contents this
+    // load has just replaced, so discard them all. Without this the recompiler
+    // keeps running stale code: input stops responding, sound distorts, and
+    // execution eventually jumps to a wild address.
+    //
+    // Do not use cpu_term()/init_cpu() for this. init_cpu() memsets reg[] and
+    // resets the PC, which throws away the state just restored and restarts the
+    // game from the BIOS.
+    flush_translation_cache(TRANSLATION_REGION_READONLY, FLUSH_REASON_LOADING_ROM);
+    flush_translation_cache(TRANSLATION_REGION_WRITABLE, FLUSH_REASON_NATIVE_BRANCHING);
+  }
+  else
+  {
+    // Nothing was restored: the file is missing or too short. Report it,
+    // because silently doing nothing is indistinguishable from a successful
+    // load.
+    FILE *debug_log = fopen("froglog.txt", "a");
+    if (debug_log) {
+      fprintf(debug_log, "LOAD_STATE: nothing loaded - '%s' missing or too small\n",
+              savestate_path);
+      fclose(debug_log);
+    }
   }
 
   scePowerUnlock(0);

--- a/source/src/memory.h
+++ b/source/src/memory.h
@@ -149,6 +149,7 @@ extern char gamepak_filename_raw[MAX_FILE];
 extern SceUID gamepak_file_large;
 extern u8 *gamepak_rom;
 extern u32 gamepak_ram_buffer_size;
+extern u32 gamepak_size;
 
 extern u32 oam_update;
 


### PR DESCRIPTION
Manual save states were unusable: selecting a slot crashed the emulator, and entering the menu at all could quit it outright. Loading a state also left the recompiler running stale code, which showed up as unresponsive controls and distorted sound.

These turned out to be three independent bugs, each hiding the next. All three are still present on `master`.

## 1. Quitting on menu exit for RAM-resident ROMs

A ROM that fits in the RAM buffer is read fully into memory and its file handle is closed deliberately — paging is inactive and the handle is never used again. But `gamepak_filename_raw` was only populated on the *paged* branch of `load_gamepak_raw`, so for RAM-resident ROMs it stayed an empty string.

`menu()` closes a valid gamepak handle on entry and parks the `-2` sentinel; on exit `gamepak_file_reopen()` opens `gamepak_filename_raw` — empty — fails all five attempts, and calls `quit()`. The handle was left holding `0x80010016` (`EINVAL`) from opening an empty path.

Since you have to enter the menu to reach a save state, every manual load hit this. Auto-resume appeared to work because it completes before the first menu visit.

Fixed by populating `gamepak_filename_raw` on both branches, and treating a failed reopen as non-fatal when paging is inactive.

## 2. Save-state slots dispatched through a nested function pointer

Selecting a slot faulted:

```
Exception - Bus error (instr)
EPC       - 0EAFE6A0     (outside RAM)
ra        - 08894FEC     (jalr v0 in menu, v0 loaded from a stack slot)
```

`SAVESTATE_OPTION` put `menu_select_savestate` — a GCC nested function declared inside `menu()` — in the option table's `action_function` slot. Taking the address of a nested function requires a trampoline, and calling through it landed on a wild address. The faulting address was identical across crashes and unaffected by flushing the translation caches, so it was not cache staleness.

Every other action option in `gui.c` already passes `NULL` and is dispatched by `line_number` in `CURSOR_SELECT`, under the comment *"Handle menu actions inline to avoid corrupted function pointers"* — the same problem, already worked around everywhere except here.

Fixed by dispatching the save-state menu the same way, matched on `current_menu` first because its rows share line numbers with the main menu's own actions. This also gives row 11 ("load state from file") a handler — its `action_function` was already `NULL` and line 11 fell through the inline switch's `default`, so that row did nothing when selected.

## 3. Stale translated blocks after loading a state

`load_state` replaces IWRAM, EWRAM, VRAM, OAM, palette and I/O wholesale but left the recompiler's translated blocks in place, so the dynarec kept executing code compiled against the pre-load contents. Symptoms were unresponsive input and distorted sound, and eventually a jump outside RAM.

Fixed by flushing both translation caches at the end of `load_state`, so every caller gets it — boot resume and manual loads alike.

Two notes on this one:

- It must **not** be done with `cpu_term()/init_cpu()`. `init_cpu()` memsets `reg[]` and resets the PC, so it discards the state that was just restored and the game cold-boots to the BIOS — a GBA logo, then a black screen with garbled sound, because RAM holds the restored contents while the CPU starts from scratch. `flush_translation_cache` leaves `reg[]` alone.
- On `v0.3.3-active` there is an existing attempt at this in `load_auto_resume_state_internal`, gated on `is_auto_resume`, but the boot path calls the other wrapper so it never ran. `master` doesn't have that code.

Also included: `gamepak_size` is now declared in `memory.h` (it was defined but never exported), and a load that restores nothing because the file is missing or shorter than a full state now says so — that case was silent and indistinguishable from success.

## Testing

Verified on hardware (PSP, Pokémon FireRed, 16 MB ROM): manual save and load across slots, the saving options menu, boot auto-resume with correct movement and sound, "load state from file", and slot previews. No crashes, and no `exception.log` produced.

Two things to be upfront about:

- **The hardware testing was done on a `v0.3.3-active` build, not this one.** `master`'s `memory.c` has diverged, so changes 1 and 3 are reapplied by hand rather than cherry-picked. This branch compiles cleanly from scratch and is logically identical, but it has not itself been run on hardware.
- **Built with `psp-gcc 15.2.0`**, which is considerably newer than the toolchain used for the v0.3.3 release. Bug 2 in particular is compiler-sensitive, so its exact symptom may differ on an older toolchain — though the fix follows the pattern already established elsewhere in the file and is correct regardless.

## Commits

- `Dispatch the save-state menu inline instead of via a nested function pointer` — bug 2
- `Show each save state's screenshot while its slot is highlighted` — feature restoration, see below
- `Stop the emulator quitting on menu exit, and flush stale blocks on state load` — bugs 1 and 3

The middle commit is a **feature restoration rather than a crash fix** and is cleanly separable. Every `.svs` begins with the screenshot it was saved with, and the save-state menu was written to display it via `menu_change_state()` — but that was only reachable through `submenu_savestate`, the menu's `init_function`, and every `MAKE_MENU` here passes `NULL` for `init_function`. With no callers the compiler dropped both functions (the build warns `'submenu_savestate' defined but not used`), so the panel showed the paused game for every slot. It is refreshed from the menu loop now, keyed on the highlighted row changing so it costs one screenshot read per cursor move rather than one per frame.

Happy to drop that commit or move it to a separate PR if you'd prefer the crash fixes on their own.
